### PR TITLE
Disable schleuder for MVP

### DIFF
--- a/kulturschleuder/src/views/ArtworkList.vue
+++ b/kulturschleuder/src/views/ArtworkList.vue
@@ -1,7 +1,7 @@
 <template>
-  <div @click="incrementIndex()">
+  <div @click="addItem()">
     <div style="display:flex; flex-wrap: wrap;">
-        <artwork-list-item v-for="artwork in artworks" :key="artwork.id" :item="artwork" class="artwork__list__item"></artwork-list-item>
+        <artwork-list-item v-for="artwork in partialArtworks" :key="artwork.id" :item="artwork" class="artwork__list__item"></artwork-list-item>
         <!-- <artwork-list-item v-for="artwork in partialArtworks" :key="artwork.id + 'y'" :item="artwork" class="artwork__list__item"></artwork-list-item> -->
     </div>
 
@@ -19,13 +19,13 @@ export default {
   },
   data () {
     return {
-      index: 1,
+      artworkCount: 1,
       artworks: []
     }
   },
   computed: {
      partialArtworks () {
-      return this.artworks.slice(0, this.index).reverse()
+      return this.artworks.slice(0, this.artworkCount).reverse()
     }
   },
   created () {
@@ -38,8 +38,8 @@ export default {
       })
   },
   methods: {
-    incrementIndex () {
-      this.index++
+    addItem () {
+      this.artworkCount++
     }
   }
 }


### PR DESCRIPTION
I rushed ahead and implemented a "add items by click" funcionality. This was not in the MVP discussed and should be excluded for now.

I left the logic intact, but iterate the complete artworks instead of `partialArtworks`