### PR TITLE
refactor artworks getter

### DIFF
--- a/app/src/store/getters.js
+++ b/app/src/store/getters.js
@@ -6,23 +6,11 @@ const getters = {
         return state.artworks[id]
     },
     getRandomizedArtworks: state => {
-        const active = []; // artworks that can be bought
-        const archive = []; // already sold artworks
-        
-        // randomize
-        Object.values(state.artworks)
-            .map((a) => ({sort: Math.random(), value: a}))
-            .sort((a, b) => a.sort - b.sort)
-            .map((a) => {
-                if (a.value.quantity < 1) { // sold
-                    archive.push(a.value)
-                } else {
-                    active.push(a.value)
-                }
-            });
-
-        // display sold artworks last
-        return active.concat(archive)
+        return Object.values(state.artworks)
+            .map(item => ({ sort: Math.random(), value: item })) // introduce random sort parameter
+            .sort((a, b) => a.sort - b.sort) // sort by random sort parameter
+            .map(item => item.value) // exclude random sort parameter
+            .sort(a => a.quantity > 0 ? -1 : 1) // move sold out items to the back
     }
 }
 


### PR DESCRIPTION
Hi @milanbargiel 

I found a nice solution for the artwork getter, that ...

* keeps the random sort order
* moves all sold out items (`quantity < 1`) to the back of the array
* is just one line :)

I had to play around a little until I got it right. compare mdn docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort