### PR TITLE
[App] add scroll-to-top on every route change ref #89

### DIFF
--- a/app/src/router/index.js
+++ b/app/src/router/index.js
@@ -34,6 +34,7 @@ router.beforeEach((to, from, next) => {
     store.commit('SET_PAYMENT_INFO', { show: false, state: 'hidden' })    
   }
   next()
+  window.scrollTo({ top: 0 });
 })
 
 export default router


### PR DESCRIPTION
Dear @milanbargiel 

please test if the line added is helping with the issue.

I wasn't able to find the reason behind this issue, so I blindly added a `scrollToTop` function.

This is executed every time the route is changing. Could become a problem if we wanted to not start at the top one day in yet to be thought of component.

fix #89 