### PR TITLE
[App] Make full image of artwork clickable

### DIFF
--- a/app/src/components/ArtworkListItem.vue
+++ b/app/src/components/ArtworkListItem.vue
@@ -1,12 +1,10 @@
 <template>
-    <div :class="['artwork-list-item', { 'artwork-list-item--sold': isSoldOut }]" :style="styles">
+    <router-link :class="['artwork-list-item', { 'artwork-list-item--sold': isSoldOut }]" :style="styles" :to="{ name: 'artworkDetail', params: { author: this.authorSlug, slug: item.slug }}">
         <responsive-image class="artwork-list-item__image" :lazy-src="imgUrl" :lazy-srcset="srcSet" :aspectRatio="aspectRatio"></responsive-image>
-        <router-link class="artwork-list-item__link" :to="{ name: 'artworkDetail', params: { author: this.authorSlug, slug: item.slug }}">
-            <span class="artwork-list-item__author">{{ item.author }}: </span>
-            <span class="artwork-list-item__title">{{ item.title }}</span> 
-            <span class="artwork-list-item__price">{{ item.price }}€</span>
-        </router-link>
-    </div>
+        <span class="artwork-list-item__author">{{ item.author }}: </span>
+        <span class="artwork-list-item__title">{{ item.title }}</span> 
+        <span class="artwork-list-item__price">{{ item.price }}€</span>
+    </router-link>
 </template>
 
 <script>

--- a/app/src/styles/ArtworkListItem.scss
+++ b/app/src/styles/ArtworkListItem.scss
@@ -54,13 +54,13 @@
 }
 
 // Underlined-link as Hoverstyle
-.artwork-list-item__link:hover,
-.artwork-list-item__link:focus {
+.artwork-list-item:hover,
+.artwork-list-item:focus {
   .artwork-list-item__author,
   .artwork-list-item__title {
     // a solution that allows to configure the line thickness (https://css-tricks.com/styling-underlines-web/)
     background-image: linear-gradient(to right, $black 100%, transparent 0%);
-    background-position: 0 20px;
+    background-position: 0 21px;
     background-repeat: repeat-x;
     background-size: 1px 1px;
   }


### PR DESCRIPTION
- If there is no [Enzo effect](http://enzomari.com/), images of the shop layer shall be clickable as such
- On click, the user is redirected to the artwork detail page

🥼 digging into details.. @moritzpflueger 

Closes #120 