### PR TITLE
[App] Lazyload artwork detail images

### DIFF
--- a/app/src/components/ResponsiveImage.vue
+++ b/app/src/components/ResponsiveImage.vue
@@ -55,7 +55,7 @@ export default {
         // set to `false`, which removes the apsect
         // ratio we've applied earlier.
         const setLoadingState = () => {
-            this.loading = true
+            this.loading = false
         };
 
         this.$el.addEventListener('load', setLoadingState)

--- a/app/src/styles/ArtworkDetail.scss
+++ b/app/src/styles/ArtworkDetail.scss
@@ -10,6 +10,7 @@
 .carousel {
   text-align: center; // center images that are reduced in size
   margin: 0 30px 12px;
+  max-height: 500px;
 
   @media screen and (min-width: $bp-tablet) {
     margin: 0 auto 30px;


### PR DESCRIPTION
- An aspect ratio is given to images on artwork detail pages, so that while loading vertical space is reserved for the image.
- The 'large' format of the image is requested, instead of the unresized original one. By doing so, bandwith is saved.

Closes #129 