### PR TITLE
Refactor image width

### DIFF
--- a/app/src/components/ArtworkListItem.vue
+++ b/app/src/components/ArtworkListItem.vue
@@ -74,7 +74,7 @@ export default {
             if (this.item.type === 'Erlebnis') {
                 return this.minWidth // do not randomize width of artworks of type "Erlebnis"
             }
-            const maxAdded = 10 // maximum added to minWidth [%]
+            const maxAdded = 12.5 // maximum added to minWidth [%]
             return Math.floor(Math.random() * maxAdded + this.minWidth)
         }
     }


### PR DESCRIPTION
* I increased the code for calculating image width, with the goal to also make it easier to understand image width calculation.
* Added a new breakpoint for medium sized screens (`680<medium size<1400`)
* I played with the percentages until I got a good result. Feel free to tweak those percentages even further.

closes #138