### PR TITLE
[App] make artist name a link

### DIFF
--- a/app/src/views/ArtworkDetail.vue
+++ b/app/src/views/ArtworkDetail.vue
@@ -13,7 +13,7 @@
     </div>
     <div class="artwork-detail__title">
       <a v-if="artwork.website" class="artwork-detail__author link" :href="artwork.website" target="_blank" rel="noopener">{{ artwork.author }}:</a>
-      <div v-else>{{ artwork.author }}</div>
+      <div v-else class="artwork-detail__author">{{ artwork.author }}</div>
       {{ artwork.title }}
     </div>
     <div class="artwork-detail__description" v-html="artwork.description">


### PR DESCRIPTION
Hi @milanbargiel, this should be an easy win. If a website is configured in the backend the artist's name will link to this website in a new window/tab.

Please note that I had to make `website` accessible for the API with removing the `private: true` property in the artwork `model`

closes #144