### PR TITLE
[App] introduce rounded moneypool balance getter

### DIFF
--- a/app/src/components/MoneypoolBanner.vue
+++ b/app/src/components/MoneypoolBanner.vue
@@ -20,8 +20,7 @@ export default {
     },
     computed: {
         balance () {
-            // toLocaleString is native js function to add the point for 1000s
-            return this.$store.state.shadowMoneypoolBalance.toLocaleString(undefined, { minimumFractionDigits: 2 })
+            return this.$store.getters.roundedMoneypoolBalance
         }
     }
 }

--- a/app/src/store/getters.js
+++ b/app/src/store/getters.js
@@ -17,6 +17,9 @@ const getters = {
             .sort((a, b) => a.sort - b.sort) // sort by random sort parameter
             .map(item => item.value) // exclude random sort parameter
             .sort(a => a.quantity > 0 ? -1 : 1) // move sold out items to the back
+    },
+    roundedMoneypoolBalance: state => {
+        return Math.round(state.shadowMoneypoolBalance).toLocaleString() // toLocaleString is native js function to add the point for 1000s
     }
 }
 


### PR DESCRIPTION
Hi @milanbargiel, also a easy one.
I used `Math.round` so it will round up and round down (not only round up as discussed). The reason is I didn't find a Math function for that, and I was to lazy to implement one by myself.. Actually I don't think it'll matter :-)