### PR TITLE
[App] fix totalCost can have too many decimals

### DIFF
--- a/app/src/components/Checkout.vue
+++ b/app/src/components/Checkout.vue
@@ -52,7 +52,7 @@ export default {
             return this.singleUnitPrice * this.orderQuantity
         },
         tax () {
-            return this.artwork.tax.substring(1); // remove dummy underscore from tax enumeration String
+            return this.artwork.tax.substring(1) // remove dummy underscore from tax enumeration String
         },
         taxShare () {
             return this.purchaseOrderPrice * this.tax/100
@@ -60,8 +60,11 @@ export default {
         priceWithTaxes () {
             return this.purchaseOrderPrice + this.taxShare
         },
+        shippingCosts () {
+            return this.artwork.shippingCosts
+        },
         totalCost () {
-            return this.priceWithTaxes + this.artwork.shippingCosts
+            return (this.priceWithTaxes + this.shippingCosts).toFixed(2)
         },
         validQuantity () {
             return this.orderQuantity <= this.artwork.quantity && this.orderQuantity > 0


### PR DESCRIPTION
Couldn't find out what the problem is, so I just threw a rough solution at it: `.toFixed(2)` parses to a String and throws away every decimal after the second.

* Every `totalCost` is now a String with 2 decimals. See Screenshots.

### result
/maurits-boettger/way-to-warmth
![image](https://user-images.githubusercontent.com/65345718/98346827-d3d12300-2016-11eb-8d6f-c0cef313a3b2.png)

/johannes-specks/bombogenese
![image](https://user-images.githubusercontent.com/65345718/98346835-d895d700-2016-11eb-82a7-3a3a03d7dd67.png)
