### PR TITLE
[App] fix random item width by session

### DIFF
--- a/app/src/components/ArtworkListItem.vue
+++ b/app/src/components/ArtworkListItem.vue
@@ -1,10 +1,10 @@
 <template>
-    <router-link :class="['artwork-list-item link', { 'artwork-list-item--sold': isSoldOut }]" :style="styles" :to="{ name: 'artworkDetail', params: { author: this.authorSlug, slug: item.slug }}">
-        <responsive-image class="artwork-list-item__image" :lazy-src="imgUrl" :lazy-srcset="srcSet" :aspectRatio="aspectRatio"></responsive-image>
-        <span class="artwork-list-item__author">{{ item.author }}<br></span>
-        <span class="artwork-list-item__title">{{ item.title }}<br></span> 
-        <span class="artwork-list-item__price">{{ item.price }}€</span>
-    </router-link>
+  <router-link :class="['artwork-list-item link', { 'artwork-list-item--sold': isSoldOut }]" :style="styles" :to="{ name: 'artworkDetail', params: { author: this.authorSlug, slug: item.slug }}">
+    <responsive-image class="artwork-list-item__image" :lazy-src="imgUrl" :lazy-srcset="srcSet" :aspectRatio="aspectRatio"></responsive-image>
+    <span class="artwork-list-item__author">{{ item.author }}<br></span>
+    <span class="artwork-list-item__title">{{ item.title }}<br></span> 
+    <span class="artwork-list-item__price">{{ item.price }}€</span>
+  </router-link>
 </template>
 
 <script>
@@ -16,78 +16,68 @@ export default {
     components: { ResponsiveImage },
     props: ['item'],
     methods: {
-        imgVariant (breakpoint) {
-            const img = this.item.images[0]
-            let url = img.url // unresized image url
-            
-            // return resized url for breakpoint if present
-            for (const format in img.formats) {
-                if (format === breakpoint && img.formats[breakpoint]) { 
-                    url = img.formats[breakpoint].url
-                }
-            }
-
-            return url
-        },
-        randomWidth (averageValue, extremeValue) {
-            // spread widths with probabilities, make extreme values appear more seldomly 
-            const value = Math.random() * averageValue
-            const possibleWidths = [value, value, value, value, value, extremeValue]
-            const randomIndex = Math.floor(Math.random() * possibleWidths.length)
-            return possibleWidths[randomIndex]
+      imgVariant (breakpoint) {
+        const img = this.item.images[0]
+        let url = img.url // unresized image url
+        
+        // return resized url for breakpoint if present
+        for (const format in img.formats) {
+          if (format === breakpoint && img.formats[breakpoint]) { 
+            url = img.formats[breakpoint].url
+          }
         }
+
+        return url
+      }
     },
     computed: {
         imgUrl () {
-            // Get 'large' variant of image, if existent
-            // If not, take the unresized one
-            return process.env.VUE_APP_API_BASEURL + this.imgVariant('large')
+          // Get 'large' variant of image, if existent
+          // If not, take the unresized one
+          return process.env.VUE_APP_API_BASEURL + this.imgVariant('large')
         },
         srcSet () {
-            // Create srcset attribute for responsive images
-            const regularImg = `${process.env.VUE_APP_API_BASEURL + this.imgVariant('large')} 1x, `
-            const retinaImg = `${process.env.VUE_APP_API_BASEURL + this.imgVariant('x2')} 2x`
+          // Create srcset attribute for responsive images
+          const regularImg = `${process.env.VUE_APP_API_BASEURL + this.imgVariant('large')} 1x, `
+          const retinaImg = `${process.env.VUE_APP_API_BASEURL + this.imgVariant('x2')} 2x`
 
-            return regularImg + retinaImg
+          return regularImg + retinaImg
         },
         aspectRatio() {
-            // Calculate the aspect ratio of the image
-            return (this.item.images[0].height / this.item.images[0].width) * 100;
+          // Calculate the aspect ratio of the image
+          return (this.item.images[0].height / this.item.images[0].width) * 100;
         },
         isSoldOut () {
-            return this.item.quantity < 1
+          return this.item.quantity < 1
         },
         authorSlug () {
-            return slugify(this.item.author)
+          return slugify(this.item.author)
         },
         styles () {
-            return {
-                width: this.item.images[0].width + 'px', // give element full width of image to reserve vertical space for lazy loading
-                maxWidth: this.randomizedWidth + '%'
-            }
+          return {
+            width: this.item.images[0].width + 'px', // give element full width of image to reserve vertical space for lazy loading
+            maxWidth: this.randomizedWidth + '%'
+          }
         },
         viewportWidth () {
-            return Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0)
+          return Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0)
         },
         minWidth () {            
-            if (this.viewportWidth < 680) {
-                return 40 // width for small screens [%]
-            }
-            if (this.viewportWidth < 1500) {
-                return 25 // width for medium screens [%]
-            }
-            return 20 // width for large screens [%]
+          if (this.viewportWidth < 680) {
+            return 40 // width for small screens [%]
+          }
+          if (this.viewportWidth < 1500) {
+            return 25 // width for medium screens [%]
+          }
+          return 20 // width for large screens [%]
         },
         randomizedWidth () {
-            if (this.item.type === 'Erlebnis') {
-                return this.minWidth // do not randomize width of artworks of type "Erlebnis"
-            }
-
-            if (this.viewportWidth < 680) {
-                return Math.floor(this.randomWidth(12.5, 36) + this.minWidth)
-            }
+          if (this.item.type === 'Erlebnis') {
+            return this.minWidth // do not randomize width of artworks of type "Erlebnis"
+          }
+          
+          return Math.floor(this.minWidth + this.item.randomWidthBase * 12.5)
             
-            return Math.floor(this.randomWidth(12.5, 20) + this.minWidth)
         }
     }
 }

--- a/app/src/store/getters.js
+++ b/app/src/store/getters.js
@@ -15,7 +15,13 @@ const getters = {
         return Object.values(state.artworks)
             .map(item => ({ sort: Math.random(), value: item })) // introduce random sort parameter
             .sort((a, b) => a.sort - b.sort) // sort by random sort parameter
-            .map(item => item.value) // exclude random sort parameter
+            .map(item => {
+                item.value.randomWidthBase = Math.random() // introduce random width base for later caluclation
+                if (item.value.randomWidthBase < .167) {
+                    item.value.randomWidthBase += 2 // bump random width base by 2 for every 6th item
+                }
+                return item.value // exclude random sort parameter
+            })
             .sort(a => a.quantity > 0 ? -1 : 1) // move sold out items to the back
     },
     roundedMoneypoolBalance: state => {


### PR DESCRIPTION
@milanbargiel 

It's done. On every reload we provide a randomly sorted list. Every item calculated it's random width itself. To change this I had to move the random factor (`Math.floor`) to the getter. The getter only gets calculated on reload and on changes to the artwork array. That's why it stays the same on navigating through the app. result: width is random but stays the same.

Unfortunately I had to destruct some of your precious algorithm, Sorry!