### PR TITLE
[App] omit updating quantity in state

### DIFF
--- a/app/src/components/Checkout.vue
+++ b/app/src/components/Checkout.vue
@@ -88,19 +88,8 @@ export default {
         return 
       }
       this.$store.dispatch('sendOrder', { artworkId: this.artwork.id, order })
-      .then(response => { 
-        this.$store.commit('UPDATE_ARTWORK_QUANTITY', response.data.artwork)
-      })
-
-      // update quantity even before it's confirmed and updated again after sendOrder success.    
-      this.$store.commit('UPDATE_ARTWORK_QUANTITY', { 
-        id: this.artwork.id,
-        quantity: this.artwork.quantity - this.orderQuantity
-      })
       this.$store.dispatch('updateShadowMoneypool', this.generatorShare)
-
-      // change route programatically to thank you page
-      this.$router.push({ name: 'purchaseConfirmation', params: { artwork: this.artwork } })
+      this.$router.push({ name: 'purchaseConfirmation', params: { artwork: this.artwork } }) // change route programatically to thank you page
     },
     loadPaypalScript () {
       const script = document.createElement('script')
@@ -124,7 +113,7 @@ export default {
             } else {
               actions.enable();
             }
-          });                        
+          });
         },
         createOrder: (data, actions) => {
           return actions.order.create({                      

--- a/app/src/store/mutations.js
+++ b/app/src/store/mutations.js
@@ -19,9 +19,6 @@ const mutations = {
     SET_ARTWORK (state, payload) {
         Vue.set(state.artworks, [payload.id], payload)
     },
-    UPDATE_ARTWORK_QUANTITY (state, payload) {
-        state.artworks[payload.id].quantity = payload.quantity
-    },
     UPDATE_SHADOW_MONEYPOOL (state, payload) {
         state.shadowMoneypoolBalance = payload
     }    


### PR DESCRIPTION
hey @milanbargiel 

with the new thank you page redirecting the user away from the artwork detail page, I think it's obsolete to update the artworks quantity. The user will never see this update (on success he is re-directed to thank you, on error the quantity won't update anyway)

This PR is clearly optional. Consider it and merge if you like.

