### PR TITLE
fix missing digits adding extra width for separator #203

### DIFF
--- a/app/src/components/MenuItem.vue
+++ b/app/src/components/MenuItem.vue
@@ -82,8 +82,13 @@ export default {
           animatedBalance: function() {	
             return parseInt(this.tweenedNumber.toFixed(0))
           },	
-          balanceItemWidth () {	
-            return this.moneypoolBalance.toString().length * 50 + 'px' // 50 is approximately the width of a single number
+          balanceItemWidth () {
+            let digits = this.moneypoolBalance.toString().length
+            const digitWidth = 50
+            if (digits >= 4) {
+              digits += 1
+            }
+            return digits * digitWidth + 'px'        
           }        
         }
       }


### PR DESCRIPTION
good morning @milanbargiel,

I couldn't resists.. Just fixed the missing digits in the moneypool banner.
* for amounts > 1000 an separator gets added
* Each digit gets assigned a width
* all digit width get summed up to become the marquee-item width (no annoying jumping on increase animation) 
* had to assign a width to the separator to make it work.

closes #203 