### PR TITLE
[App] do not animate balance below 100

### DIFF
--- a/app/src/components/MenuItem.vue
+++ b/app/src/components/MenuItem.vue
@@ -80,6 +80,9 @@ export default {
             return 10 - this.item.speed
           },
           animatedBalance: function() {	
+            if (this.moneypoolBalance < 100) {
+              return this.moneypoolBalance
+            }
             return parseInt(this.tweenedNumber.toFixed(0))
           },	
           balanceItemWidth () {


### PR DESCRIPTION
easy win
* animation is still calculated in the background
* but below 100 it's just not displayed
* instead the actualy moneypool balance is displayed

I found this to be the quickest and easiest solution

closes #213 