### PR TITLE
[App/CMS] include paypal fee in moneypool banner update and email-sol…

### DIFF
--- a/app/src/components/Checkout.vue
+++ b/app/src/components/Checkout.vue
@@ -75,7 +75,9 @@ export default {
       if (!this.artwork.generatorShare) {
         return 0
       }
-      return this.artwork.price * parseInt(this.artwork.generatorShare.substring(1)) / 100
+      const baseShare = this.artwork.price * parseInt(this.artwork.generatorShare.substring(1)) / 100
+      const paypalFee = ((baseShare * 2.49/100) + 0.35).toFixed(2)
+      return baseShare - paypalFee 
     }
   },
   mounted () {
@@ -87,7 +89,7 @@ export default {
         this.error = true
         return 
       }
-      this.$store.dispatch('sendOrder', { artworkId: this.artwork.id, order })
+      this.$store.dispatch('sendOrder', { artworkId: this.artwork.id, order, share: this.generatorShare })
       .then(response => { 
         this.$store.commit('UPDATE_ARTWORK_QUANTITY', response.data.artwork)
       })

--- a/app/src/store/actions.js
+++ b/app/src/store/actions.js
@@ -57,7 +57,7 @@ const actions = {
             context.commit('UPDATE_SHADOW_MONEYPOOL', response.data.currentBalance)
         })
     },
-    sendOrder (context, { artworkId, order }) {
+    sendOrder (context, { artworkId, order, share }) {
         return axios({
             method: 'post',
             url: process.env.VUE_APP_API_BASEURL + '/orders',
@@ -70,7 +70,8 @@ const actions = {
                 buyerStreet: order.purchase_units[0].shipping.address.address_line_1,
                 buyerCity: order.purchase_units[0].shipping.address.admin_area_2,
                 buyerState: order.purchase_units[0].shipping.address.admin_area_1,
-                buyerZipCode: order.purchase_units[0].shipping.address.postal_code
+                buyerZipCode: order.purchase_units[0].shipping.address.postal_code,
+                generatorShare: share
             }
         })
         .then(response => {

--- a/cms/api/order/controllers/order.js
+++ b/cms/api/order/controllers/order.js
@@ -19,6 +19,8 @@ module.exports = {
     const entity = await strapi.services.order.create(ctx.request.body);
     const entry = sanitizeEntity(entity, { model: strapi.models.order });
 
+    entry.generatorShare = ctx.request.body.generatorShare;
+
     if (entry) {
       // Pass entry data to templates
       const buyerMail = await strapi.plugins['email'].services.email.renderMail(entry, 'artwork-purchased');

--- a/cms/mail-templates/artwork-sold/text.pug
+++ b/cms/mail-templates/artwork-sold/text.pug
@@ -1,5 +1,5 @@
 - var generatorShare = entry.artwork.generatorShare.substring(1); // Remove dummy underscore
-- var shareInEur = ((entry.orderQuantity * entry.artwork.price) * (generatorShare/100)).toFixed(2);
+- var shareInEur = (entry.orderQuantity * entry.generatorShare).toFixed(2);
 
 | Hallo #{entry.artwork.author},
 |
@@ -17,6 +17,8 @@
 | Bei der Einreichung Ihres Angebots haben Sie sich bereit erklärt #{generatorShare}% des Brutto-Verkaufspreises solidarisch zu verteilen. Wir bitten daher um Überweisung des entsprechenden Betrages von #{shareInEur}€ auf das PayPal-Konto des Kulturgenerators:
 |
 | https://www.paypal.me/kulturgenerator/#{shareInEur}
+|
+| Etwaige Gebühren, die von Seiten PayPals anfallen können wurden bei der Berechnung des Betrags berücksichtigt.
 |
 | Danke fürs Mitmachen, Teilen und Unterstützen.
 |

--- a/cms/mail-templates/artwork-sold/text.pug
+++ b/cms/mail-templates/artwork-sold/text.pug
@@ -1,5 +1,5 @@
 - var generatorShare = entry.artwork.generatorShare.substring(1); // Remove dummy underscore
-- var shareInEur = (entry.orderQuantity * entry.generatorShare).toFixed(2);
+- var shareInEur = (entry.orderQuantity * entry.generatorShare).toFixed(2); // entry.generatorShare is the share minus the paypal fee of 2,49% + 0,35€
 
 | Hallo #{entry.artwork.author},
 |
@@ -18,7 +18,7 @@
 |
 | https://www.paypal.me/kulturgenerator/#{shareInEur}
 |
-| Etwaige Gebühren, die von Seiten PayPals anfallen können wurden bei der Berechnung des Betrags berücksichtigt.
+| Die Transaktionsgebühren, die von Seiten PayPals anfallen (2,49 % + 0,35 EUR Festgebühr) wurden von Ihrem Beitrag zum Solidarkonto bereits abgezogen, damit Sie diese Kosten nicht selbst tragen müssen.
 |
 | Danke fürs Mitmachen, Teilen und Unterstützen.
 |


### PR DESCRIPTION
@milanbargiel I included the paypal fee in the moneypool banner update and the artwork-sold email template based on the same calculation done in `Checkout.vue`

I found it important to have only 1 place to calculate the paypal fee. Because Frontend and Backend were included I decided to do the calculation in the Frontend and pass it to the `orders` controller in Strapi.

Not the bestest workflow IMO, but it get's the job done for now.

closes #211 