### PR TITLE
[CMS] Add regular bank payments for solidary fund

### DIFF
--- a/cms/mail-templates/artwork-sold/text.pug
+++ b/cms/mail-templates/artwork-sold/text.pug
@@ -14,11 +14,13 @@
 | #{entry.buyerZipCode} #{entry.buyerCity}
 | #{entry.buyerEmail}
 |
-| Bei der Einreichung Ihres Angebots haben Sie sich bereit erklärt #{generatorShare}% des Brutto-Verkaufspreises solidarisch zu verteilen. Wir bitten daher um Überweisung des entsprechenden Betrages von #{shareInEur}€ auf das PayPal-Konto des Kulturgenerators:
+| Bei der Einreichung Ihres Angebots haben Sie sich bereit erklärt #{generatorShare}% des Brutto-Verkaufspreises solidarisch zu verteilen. Wir bitten daher um Überweisung des entsprechenden Betrages von #{shareInEur}€ auf das Konto des Kulturgenerators:
 |
-| https://www.paypal.me/kulturgenerator/#{shareInEur}
+| Zahlungsempfänger: Kölner Kultur. Kulturgenerator
+| IBAN: DE16 3705 0198 1935 4114 45
+| Verwendungszwecks: BS-#{entry.id}
 |
-| Die Transaktionsgebühren, die von Seiten PayPals anfallen (2,49 % + 0,35 EUR Festgebühr) wurden von Ihrem Beitrag zum Solidarkonto bereits abgezogen, damit Sie diese Kosten nicht selbst tragen müssen.
+| Die Transaktionsgebühren, die von Seiten PayPals durch den Verkauf anfielen (2,49 % + 0,35 EUR Festgebühr) wurden von Ihrem Beitrag zum Solidarkonto abgezogen, damit Sie diese Kosten nicht selbst tragen müssen.
 |
 | Danke fürs Mitmachen, Teilen und Unterstützen.
 |


### PR DESCRIPTION
The PayPal fee is a pain. Therefore all payments to the solidary fund shall be made via regular bank transactions.
@moritzpflueger 